### PR TITLE
Fix blocking input with async function

### DIFF
--- a/nuke_server.py
+++ b/nuke_server.py
@@ -40,6 +40,10 @@ WHITELIST = [
     0000000000000000
 ]
 
+async def async_input(prompt: str) -> str:
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(None, input, prompt)
+
 async def get_token():
     if os.path.exists(TOKEN_FILE):
         with open(TOKEN_FILE, 'r') as file:
@@ -214,8 +218,8 @@ async def on_ready():
         logging.info(f"Connected to the server: {guild.name}")
 
         print("\nOptions:\n1. Nuke all (without kicking members)\n2. Delete channels\n3. Delete roles\n4. Ban members\n5. Kick members\n6. Delete emojis\n7. Delete server\n8. Delete invites\n9. Delete webhooks\n10. Spam message\n11. Lockdown channels")
-        option = input("Enter nuke option number (1-11): ").strip()
-        await nuke(guild, option)
+        option = await async_input("Enter nuke option number (1-11): ")
+        await nuke(guild, option.strip())
     else:
         print("Server not found.")
         logging.error("Server not found.")

--- a/tests/test_async_input.py
+++ b/tests/test_async_input.py
@@ -1,0 +1,44 @@
+import asyncio
+import unittest
+from unittest.mock import patch
+import sys
+import types
+
+# Provide a dummy discord module so nuke_server can be imported without the
+# real dependency installed.
+discord_stub = types.ModuleType('discord')
+
+class DummyIntents:
+    @classmethod
+    def default(cls):
+        return cls()
+
+discord_stub.Intents = DummyIntents
+
+class DummyClient:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def event(self, func):
+        return func
+
+discord_stub.Client = DummyClient
+discord_stub.utils = types.SimpleNamespace(get=lambda *args, **kwargs: None)
+discord_stub.PermissionOverwrite = type('PermissionOverwrite', (), {})
+
+sys.modules.setdefault('discord', discord_stub)
+
+tqdm_stub = types.ModuleType('tqdm')
+tqdm_stub.tqdm = lambda *args, **kwargs: None
+sys.modules.setdefault('tqdm', tqdm_stub)
+
+from nuke_server import async_input
+
+class TestAsyncInput(unittest.IsolatedAsyncioTestCase):
+    @patch('builtins.input', return_value='5')
+    async def test_async_input_returns_value(self, mock_input):
+        result = await asyncio.wait_for(async_input('Enter:'), timeout=1)
+        self.assertEqual(result, '5')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- handle interactive input asynchronously so Discord client doesn't freeze
- add isolated async test for async_input helper